### PR TITLE
Add copy buttons to prompt boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,13 @@
       mapping.forEach(({ id, label }) => {
         const textarea = document.getElementById(id);
         if (!textarea) return;
-        const button = document.createElement('button');
-        button.textContent = label;
-        button.addEventListener('click', () => {
+
+        const group = document.createElement('div');
+        group.className = 'btn-group';
+
+        const tryBtn = document.createElement('button');
+        tryBtn.textContent = label;
+        tryBtn.addEventListener('click', () => {
           const prompt = textarea.value.trim();
           if (prompt) {
             const url =
@@ -68,7 +72,21 @@
             window.open(url, '_blank');
           }
         });
-        textarea.parentNode.insertBefore(button, textarea.nextSibling);
+
+        const copyBtn = document.createElement('button');
+        copyBtn.textContent = 'copy📸';
+        copyBtn.addEventListener('click', () => {
+          const prompt = textarea.value.trim();
+          if (prompt) {
+            navigator.clipboard.writeText(prompt).catch(err =>
+              console.error('Copy failed', err)
+            );
+          }
+        });
+
+        group.appendChild(tryBtn);
+        group.appendChild(copyBtn);
+        textarea.parentNode.insertBefore(group, textarea.nextSibling);
       });
     });
   </script>

--- a/style.css
+++ b/style.css
@@ -23,3 +23,5 @@ button:hover{background:var(--btn-h);}
 .outputs h2{margin:.25rem 0 1rem;font-size:1.1rem;}
 textarea{width:100%;min-height:80px;background:#111;color:var(--accent);border:none;border-radius:4px;padding:.5rem;font-family:monospace;font-size:.85rem;margin-top:.25rem;}
 .controls{display:flex;gap:.5rem;flex-wrap:wrap;margin:1rem 0;}
+.btn-group{display:flex;gap:.5rem;margin-top:.25rem;}
+.btn-group button{flex:1;}


### PR DESCRIPTION
## Summary
- group output buttons in `btn-group`
- add "copy📸" button beside "Try it on! ✨"
- style `btn-group` for two-button rows

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68856714900c832b88f356fea40da4dc